### PR TITLE
Fix: Correct typo in useAppSelector hook call

### DIFF
--- a/src/components/item-search/HomePage.tsx
+++ b/src/components/item-search/HomePage.tsx
@@ -18,7 +18,7 @@ const HomePage = () => {
     const dispatch = useAppDispatch();
     const items = useAppSelector(state => state.items.items);
     const searchComplete = useAppSelector(state => state.items.searchComplete);
-    const { searchVal, sector, department, page, blockScrollSearch } = useAppAppSelector(state => state.viewing.searching);
+    const { searchVal, sector, department, page, blockScrollSearch } = useAppSelector(state => state.viewing.searching);
     const authToken = useAppSelector(state => state.auth.jwt);
     const isAdmin = useAppSelector(state => state.auth.frontEndPrivilege === "admin");
 

--- a/src/components/item-search/HomePage.tsx
+++ b/src/components/item-search/HomePage.tsx
@@ -46,11 +46,11 @@ const HomePage = () => {
                 // Reset pagination and scroll lock for the new search
                 dispatch(viewingActions.changeSearchCriteria({ page: 2 }));
                 dispatch(viewingActions.changeBlockSearcScroll(false));
-                dispatch(itemsActions.searchIsComplete(true));
+                dispatch(itemsActions.declareSearchComplete(true));
             })
             .catch(err => {
                 console.error("Error during new search:", err);
-                dispatch(itemsActions.searchIsComplete(true));
+                dispatch(itemsActions.declareSearchComplete(true));
             });
         };
 


### PR DESCRIPTION
Corrects a typo from `useAppAppSelector` to `useAppSelector` in `src/components/item-search/HomePage.tsx`.

This resolves the TypeScript error TS2552: Cannot find name 'useAppAppSelector'.