### PR TITLE
Fix: Add missing dependencies to useEffect in ItemPage

### DIFF
--- a/src/components/item-page/ItemPage.tsx
+++ b/src/components/item-page/ItemPage.tsx
@@ -79,7 +79,7 @@ const ItemPage = () => {
             setItem(null);
         }
         // We removed `frontEndPrivilege`, `dispatch`, and `navigate` because they are stable and don't need to trigger re-fetches.
-    }, [params.itemid, authToken, navigate]);
+    }, [params.itemid, authToken, navigate, dispatch, frontEndPrivilege]);
 
 
     // highlight-start


### PR DESCRIPTION
Adds `dispatch` and `frontEndPrivilege` to the dependency array of the main data-fetching useEffect in `src/components/item-page/ItemPage.tsx`.

This resolves the `react-hooks/exhaustive-deps` ESLint warning. Including `frontEndPrivilege` ensures the effect re-evaluates item access and admin-specific logic if user privileges change.