### PR TITLE
Debug: Add console log for admin status in HomePage

### DIFF
--- a/src/components/item-search/HomePage.tsx
+++ b/src/components/item-search/HomePage.tsx
@@ -20,7 +20,13 @@ const HomePage = () => {
     const searchComplete = useAppSelector(state => state.items.searchComplete);
     const { searchVal, sector, department, page, blockScrollSearch } = useAppSelector(state => state.viewing.searching);
     const authToken = useAppSelector(state => state.auth.jwt);
-    const isAdmin = useAppSelector(state => state.auth.frontEndPrivilege === "admin");
+    const userPrivilege = useAppSelector(state => state.auth.frontEndPrivilege); // Debug
+    const isAdmin = userPrivilege === "admin";
+
+    // For debugging admin status
+    useEffect(() => {
+        console.log("[HomePage] User Privilege:", userPrivilege, "Is Admin:", isAdmin);
+    }, [userPrivilege, isAdmin]);
 
     // highlight-start
     // 1. Add local state to manage the archive checkbox


### PR DESCRIPTION
Adds a useEffect hook with console logging to `HomePage.tsx` to display the current `frontEndPrivilege` from the Redux store and the derived `isAdmin` boolean value.

This is for diagnostic purposes to help determine why the "Show archived items" checkbox might not be visible for admin users.